### PR TITLE
converted css to scss, trying out css within the nintendo page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem "open-uri"
 # For markdown conversion
 gem 'pandoc-ruby'
 
+gem "sassc-rails"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,14 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -221,6 +229,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.0.8)
     thor (1.3.0)
+    tilt (2.3.0)
     time (0.2.2)
       date
     timeout (0.4.0)
@@ -265,6 +274,7 @@ DEPENDENCIES
   pg (~> 1.5.4)
   puma (~> 6.4.0)
   rails (~> 7.1)
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,0 +1,56 @@
+.card {
+  --background: linear-gradient(to left, #f7ba2b 0%, #ea5358 100%);
+  width: 190px;
+  height: 254px;
+  padding: 5px;
+  border-radius: 1rem;
+  overflow: visible;
+  background: #f7ba2b;
+  background: var(--background);
+  position: relative;
+  z-index: 1;
+ }
+
+ .card::after {
+  position: absolute;
+  content: "";
+  top: 30px;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  height: 100%;
+  width: 100%;
+  transform: scale(0.8);
+  filter: blur(25px);
+  background: #f7ba2b;
+  background: var(--background);
+  transition: opacity .5s;
+ }
+
+ .card-info {
+  --color: #181818;
+  background: var(--color);
+  color: var(--color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  border-radius: .7rem;
+ }
+
+ .card .title {
+  font-weight: bold;
+  letter-spacing: .1em;
+ }
+
+ /*Hover*/
+ .card:hover::after {
+  opacity: 0;
+ }
+
+ .card:hover .card-info {
+  color: #f7ba2b;
+  transition: color 1s;
+ }

--- a/app/assets/stylesheets/_home.scss
+++ b/app/assets/stylesheets/_home.scss
@@ -1,0 +1,6 @@
+body {
+  background-color: black;
+  background-size: 100%;
+  color: white;
+  text-align: center;
+}

--- a/app/assets/stylesheets/_inputs.scss
+++ b/app/assets/stylesheets/_inputs.scss
@@ -1,0 +1,48 @@
+.container {
+  position: relative;
+  --size-button: 40px;
+  color: white;
+}
+
+.input {
+  padding-left: var(--size-button);
+  height: var(--size-button);
+  font-size: 15px;
+  border: none;
+  color: #fff;
+  outline: none;
+  width: var(--size-button);
+  transition: all ease 0.3s;
+  background-color: #191A1E;
+  box-shadow: 1.5px 1.5px 3px #0e0e0e, -1.5px -1.5px 3px RGB(95 94 94 / 25%), inset 0px 0px 0px #0e0e0e, inset 0px -0px 0px #5f5e5e;
+  border-radius: 50px;
+  cursor: pointer;
+}
+
+.input:focus,
+.input:not(:invalid) {
+  width: 200px;
+  cursor: text;
+  box-shadow: 0px 0px 0px #0e0e0e, 0px 0px 0px RGB(95 94 94 / 25%), inset 1.5px 1.5px 3px #0e0e0e, inset -1.5px -1.5px 3px #5f5e5e;
+}
+
+.input:focus + .icon,
+.input:not(:invalid) + .icon {
+  pointer-events: all;
+  cursor: pointer;
+}
+
+.container .icon {
+  position: absolute;
+  width: var(--size-button);
+  height: var(--size-button);
+  top: 0;
+  left: 0;
+  padding: 8px;
+  pointer-events: none;
+}
+
+.container .icon svg {
+  width: 100%;
+  height: 100%;
+}

--- a/app/assets/stylesheets/_nintendo.scss
+++ b/app/assets/stylesheets/_nintendo.scss
@@ -1,0 +1,88 @@
+.flex-container {
+  display: flex;
+  justify-content: space-around;
+}
+
+
+
+.loadingio-spinner-spinner-2pcnwbnmf5e {
+  @keyframes ldio-4vh0oxhxr1f {
+    0% { opacity: 1 }
+    100% { opacity: 0 }
+  }
+  .ldio-4vh0oxhxr1f div {
+    left: 94px;
+    top: 48px;
+    position: absolute;
+    animation: ldio-4vh0oxhxr1f linear 1s infinite;
+    background: #fe718d;
+    width: 12px;
+    height: 24px;
+    border-radius: 6px / 12px;
+    transform-origin: 6px 52px;
+  }.ldio-4vh0oxhxr1f div:nth-child(1) {
+    transform: rotate(0deg);
+    animation-delay: -0.9166666666666666s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(2) {
+    transform: rotate(30deg);
+    animation-delay: -0.8333333333333334s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(3) {
+    transform: rotate(60deg);
+    animation-delay: -0.75s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(4) {
+    transform: rotate(90deg);
+    animation-delay: -0.6666666666666666s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(5) {
+    transform: rotate(120deg);
+    animation-delay: -0.5833333333333334s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(6) {
+    transform: rotate(150deg);
+    animation-delay: -0.5s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(7) {
+    transform: rotate(180deg);
+    animation-delay: -0.4166666666666667s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(8) {
+    transform: rotate(210deg);
+    animation-delay: -0.3333333333333333s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(9) {
+    transform: rotate(240deg);
+    animation-delay: -0.25s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(10) {
+    transform: rotate(270deg);
+    animation-delay: -0.16666666666666666s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(11) {
+    transform: rotate(300deg);
+    animation-delay: -0.08333333333333333s;
+    background: #fe718d;
+  }.ldio-4vh0oxhxr1f div:nth-child(12) {
+    transform: rotate(330deg);
+    animation-delay: 0s;
+    background: #fe718d;
+  }
+  .loadingio-spinner-spinner-2pcnwbnmf5e {
+    width: 200px;
+    height: 200px;
+    display: inline-block;
+    overflow: hidden;
+    background: #000000;
+  }
+  .ldio-4vh0oxhxr1f {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    transform: translateZ(0) scale(1);
+    backface-visibility: hidden;
+    transform-origin: 0 0; /* see note above */
+  }
+  .ldio-4vh0oxhxr1f div { box-sizing: content-box; }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+@import "home";
+@import "nintendo";
+@import "cards";
+@import "inputs";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  helper :search
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,17 @@
+module SearchHelper
+  def search_input(name, placeholder, required = true, classes = 'input')
+    content_tag :div, class: 'container' do
+      concat text_field_tag(name, nil, class: classes, required: required, placeholder: placeholder)
+      concat(
+        content_tag(:div, class: 'icon') do
+          tag.svg(
+            content_tag(:title, 'Search') +
+            tag.path(nil, d: 'M221.09 64a157.09 157.09 0 10157.09 157.09A157.1 157.1 0 00221.09 64z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '32') +
+            tag.path(nil, fill: 'none', stroke: 'currentColor', 'stroke-linecap': 'round', 'stroke-miterlimit': '10', 'stroke-width': '32', d: 'M338.29 338.29L448 448'),
+            xmlns: 'http://www.w3.org/2000/svg', class: 'ionicon', viewBox: '0 0 512 512'
+          )
+        end
+      )
+    end
+  end
+end

--- a/app/views/games/nintendo.html.erb
+++ b/app/views/games/nintendo.html.erb
@@ -5,4 +5,26 @@
   <%= f.file_field :main_image %>
 
   <%= f.submit %>
+
+  <%= search_input('text', 'Type to Search...') %>
+
+
+
+  <div class="card">
+  <div class="card-info">
+    <p class="title">Magic Card</p>
+    <ul class="flex-container">
+      <li class="flex-item">1</li>
+      <li class="flex-item">2</li>
+      <li class="flex-item">3</li>
+      <li class="flex-item">4</li>
+      <li class="flex-item">5</li>
+      <li class="flex-item">6</li>
+    </ul>
+  </div>
+
+<div class="loadingio-spinner-spinner-2pcnwbnmf5e"><div class="ldio-4vh0oxhxr1f">
+<div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
+</div></div>
+
 <% end %>

--- a/public/404.html
+++ b/public/404.html
@@ -28,7 +28,7 @@
     border-top-right-radius: 9px;
     background-color: white;
     padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
@@ -49,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
   </style>
 </head>

--- a/public/422.html
+++ b/public/422.html
@@ -28,7 +28,7 @@
     border-top-right-radius: 9px;
     background-color: white;
     padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
@@ -49,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
   </style>
 </head>

--- a/public/500.html
+++ b/public/500.html
@@ -28,7 +28,7 @@
     border-top-right-radius: 9px;
     background-color: white;
     padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
@@ -49,7 +49,7 @@
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
     color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    box-shadow: 0 3px 8px RGBa(50, 50, 50, 0.17);
   }
   </style>
 </head>


### PR DESCRIPTION
Added gem sassc-rails to perform scss instead of css.

Added scss style pages for each of inputs and cards components, homepage and Nintendo pages.

Started a list within a flex container to simulate how flexbox would structurally appear with game cards/covers in the future, temporarily superseded in this commit by the newly added scss cards appearance.

Helper setup for search input, albeit not as intended in its positioning yet.