### PR TITLE
destroy, edit and update game actions setup

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,16 +6,12 @@ class GamesController < ApplicationController
       flash[:success] = "Game created successfully."
       redirect_to games_path
     else
-      render 'new'
+      render :new, status: :unprocessable_entity
     end
   end
 
   def new
     @game = Game.new
-  end
-
-  def edit
-    @restaurant = Restaurant.find(params[:id])
   end
 
   def index
@@ -40,9 +36,29 @@ class GamesController < ApplicationController
     @game = Game.find(params[:id])
   end
 
+  def edit
+    @game = Game.find(params[:id])
+  end
+
+  def update
+    @game = Game.find(params[:id])
+    if @game.update(game_params)
+      flash[:success] = "This game has been updated successfully."
+      redirect_to games_path(@game)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @game = Game.find(params[:id])
+    @game.destroy
+    redirect_to games_path, status: :see_other
+  end
+
   private
 
   def game_params
-    params.require(:game).permit(:title, :description, :review_scores, :main_image)
+    params.require(:game).permit(:title, :description, :game_scores, :main_image)
   end
 end

--- a/app/views/games/destroy.html.erb
+++ b/app/views/games/destroy.html.erb
@@ -1,0 +1,3 @@
+
+
+<%= link_to "Return to Games", index_path %>

--- a/app/views/games/edit.html.erb
+++ b/app/views/games/edit.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: @game, url: game_path(@game), local: true do |f| %>
+  <%= render 'form' %>
+  <%= f.submit "Update Game" %>
+<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,12 +1,22 @@
 <div class="game">
   <h1><%= @game.title %></h1>
   <h2><%= @game.description %></h2>
-  <p>Review Scores: <%= @game.review_scores %></p>
+  <p>Game Review Score: <%= @game.review_scores %></p>
   <% if @game.main_image.attached? %>
     <%= image_tag @game.main_image, size: "250x400" %>
   <% else %>
      <%= image_tag("default.png", size: "250x400") %>
   <% end %>
 </div>
+
+<%= link_to "Edit", edit_game_path(@game.id) %>
+
+<li class="list-group-item">
+  <%= @game.title %>
+  <%= link_to "Delete",
+    game_path(@game),
+    data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}
+  %>
+</li>
 
 <%= link_to "Return to Games", index_path %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,6 +5,7 @@
 <%= link_to "All about Nintendo", nintendo_path %>
 <%= link_to "Games", index_path %>
 <%= link_to "About", about_path %>
+<%= link_to "Delete", games_path(@game), method: :delete %>
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
 
   get "home", to: 'pages#home', as: :homepage
   get "about", to: "pages#about", as: :about
+
   get "index", to: "games#index", as: :index
+  get "delete", to: "games#delete", as: :delete
+  get "edit", to: "games#edit", as: :edit
 
   get "nintendo", to: "games#nintendo", as: :nintendo
 


### PR DESCRIPTION
Destroy, edit and update have been implemented. 

Destroy is able to delete specific game records and provides a modal prompt to gain the user's confirmation to avoid accidental deletions.

Edit allows the ability to edit existing game records but not complete the action and therefore unable to save it and return to the game index, will resolve this.

Routes adjusted for new CRUD actions accordingly.

Have already update locally back to "review_scores" instead of "game_scores" in the Games controller.

