### PR TITLE
Setup friendly_id gem to handle custom URL's for Game records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,12 +64,13 @@ gem 'simple_form'
 gem 'bundler-audit'
 
 # fontawesome for icons such as the gamepoad
-
 gem "font-awesome-sass", "~> 6.5.0"
 
 # For pagination and less rcords appearing per page
-
 gem 'pagy', '~> 6.2'
+
+# For records showing their titles instead of record ID's
+gem 'friendly_id', '~> 5.4.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -92,3 +93,5 @@ group :development, :test do
 end
 
 gem "dockerfile-rails", ">= 1.6", :group => :development
+
+gem "kamal", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.1.1)
+    bcrypt_pbkdf (1.1.0)
     bigdecimal (3.1.4)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -107,8 +108,10 @@ GEM
     diff-lcs (1.5.0)
     dockerfile-rails (1.6.0)
       rails (>= 3.0.0)
+    dotenv (2.8.1)
     drb (2.1.1)
       ruby2_keywords
+    ed25519 (1.3.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -125,6 +128,8 @@ GEM
     ffi (1.16.3)
     font-awesome-sass (6.5.0)
       sassc (~> 2.0)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -142,6 +147,16 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kamal (1.3.0)
+      activesupport (>= 7.0)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 2.8)
+      ed25519 (~> 1.2)
+      net-ssh (~> 7.0)
+      sshkit (~> 1.21)
+      thor (~> 1.2)
+      zeitwerk (~> 2.5)
     loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -164,8 +179,11 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.4.0)
       net-protocol
+    net-ssh (7.2.1)
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
@@ -271,6 +289,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sshkit (1.21.6)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.0.8)
@@ -317,9 +338,11 @@ DEPENDENCIES
   factory_bot_rails
   faker
   font-awesome-sass (~> 6.5.0)
+  friendly_id (~> 5.4.0)
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  kamal (~> 1.3)
   nokogiri (~> 1.15, >= 1.15.4)
   open-uri
   pagy (~> 6.2)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -46,6 +46,7 @@ class GamesController < ApplicationController
   end
 
   def show
+    @game = Game.friendly.find(params[:id])
   end
 
   def edit
@@ -75,6 +76,6 @@ class GamesController < ApplicationController
   end
 
   def find_game
-    @game = Game.find(params[:id])
+    @game = Game.friendly.find(params[:id])
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,8 +1,11 @@
 class Game < ApplicationRecord
+  extend FriendlyId
+  friendly_id :title, use: :slugged
+
   validates :title, presence: true
   validates :description, presence: true, length: { in: 5..250 }
   validates :review_scores, presence: true
   has_one_attached :main_image
 
   broadcasts_refreshes
-end
+ end

--- a/db/migrate/20231221225943_add_slug_to_games.rb
+++ b/db/migrate/20231221225943_add_slug_to_games.rb
@@ -1,0 +1,6 @@
+class AddSlugToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :slug, :string
+    add_index :games, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_03_182338) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_21_225943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_03_182338) do
     t.integer "review_scores"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
+    t.index ["slug"], name: "index_games_on_slug", unique: true
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
Added the friendly_id gem to change standardised id record numbers from appearing for game records, instead the game titles appear in the URL instead. Database, game model and controllers updated to factor in the friendly_id gem changes.