### PR TITLE
Added Password Complexity and Required Admin Approval

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,12 @@ class User < ApplicationRecord
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  def active_for_authentication?
+    super && approved?
+  end
+
+  def inactive_message
+    approved? ? super : :not_approved
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 10..50 # Minimum of 10 characters for the password and a maximum of 50 characters
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,8 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      user:
+        not_approved: 'You have signed up successfully but your account has not been approved by your administrator yet'
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -41,6 +43,7 @@ en:
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_not_approved: 'You have signed up successfully but your account has not been approved by your administrator yet'
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
@@ -58,6 +61,9 @@ en:
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
+      password_too_short: "must be at least %{count} characters"
+      password_too_long: "must be at most %{count} characters"
+      not_approved: 'Your account has not been approved by your administrator yet.'
       not_found: "not found"
       not_locked: "was not locked"
       not_saved:

--- a/db/migrate/20231227183721_add_approved_to_user.rb
+++ b/db/migrate/20231227183721_add_approved_to_user.rb
@@ -1,0 +1,11 @@
+class AddApprovedToUser < ActiveRecord::Migration[7.1]
+  def self.up
+    add_column :users, :approved, :boolean, :default => false, :null => false
+    add_index  :users, :approved
+  end
+
+  def self.down
+    remove_index  :users, :approved
+    remove_column :users, :approved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_22_233234) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_27_183721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_22_233234) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.boolean "approved", default: false, null: false
+    t.index ["approved"], name: "index_users_on_approved"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Increased the minimum and descreased the maximum characters required to create a successful account creating/altering password.

Ahead of future authorisation implementation via site administration, added to the user model, database migration and the devise yml for admin required to approve already created accounts and newly created accounts before they can be used.