### PR TITLE
Introduced devise password gem & database changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'devise'
 # For further Devise configuration and security
 gem 'devise-security'
 
+# For restricting users from using commonly used passwords
+gem 'devise-uncommon_password'
+
 # For the removal fo leftover code
 gem 'leftovers', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
       warden (~> 1.2.3)
     devise-security (0.18.0)
       devise (>= 4.3.0)
+    devise-uncommon_password (0.4.5)
+      devise (>= 3.5, < 5.0)
+      rails (>= 4.2, < 7.2)
     diff-lcs (1.5.0)
     dockerfile-rails (1.6.0)
       rails (>= 3.0.0)
@@ -361,6 +364,7 @@ DEPENDENCIES
   debug
   devise
   devise-security
+  devise-uncommon_password
   dockerfile-rails (>= 1.6)
   factory_bot_rails
   faker

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   # :session_limitable, :expirable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :timeoutable
+         :timeoutable, :uncommon_password
   has_many :posts
 
   def full_name

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,10 +27,13 @@ development:
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  username: conan
+  username: <%= ENV['POSTGRES_USER'] %>
 
   # The password associated with the PostgreSQL role (username).
-  #password:
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
+
+  # The password associated with the PostgreSQL role (username).
+
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -180,6 +180,9 @@ Devise.setup do |config|
   # Range for password length.
   config.password_length = 10..50 # Minimum of 10 characters for the password and a maximum of 50 characters
 
+  # Number of common passwords to check entered password against.
+  config.password_matches = 1000
+
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -60,6 +60,7 @@ en:
     messages:
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      common_password: 'is a very common password. Please choose something harder to guess.'
       expired: "has expired, please request a new one"
       password_too_short: "must be at least %{count} characters"
       password_too_long: "must be at most %{count} characters"


### PR DESCRIPTION
To avoid some of the most commonly used passwords being used and then making it very easy for them to be guessed, I have introduced the Devise uncommon password gem to prevent these where possible, 1000 commonly used passwords are now prevented from being available to use or change to for users. Users will get a warning message alerting them to this upon sign up for example if one a commonly used list of passwords has been used.

Also the database has been updated so it picks up from the env file instead of from the database.yml file directly.