### PR TITLE
Reverted sign up form to previous state and improved

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,9 +32,9 @@
 @import "components/btn";
 @import "components/turbo_progress_bar";
 
-
+@import 'devise_custom';
 
 
 // external libraries below
 
-@import "font-awesome";
+// @import "font-awesome";

--- a/app/assets/stylesheets/devise_custom.scss
+++ b/app/assets/stylesheets/devise_custom.scss
@@ -1,0 +1,36 @@
+.form-inputs {
+  input[type=text], input[type=password] {
+    padding: 10px;
+    margin: 10px 0;
+    border-radius: 5px;
+  }
+ }
+
+.form-actions {
+  button {
+    appearance: none;
+    -webkit-appearance: none;
+    padding: 10px;
+    border: none;
+    background-color: #3F51B5;
+    color: #fff;
+    font-weight: 600;
+    border-radius: 5px;
+    width: 100%;
+  }
+}
+
+ @media (max-width: 768px) {
+  .container-login, .container-signup, .forgetPW {
+    left: 10%;
+    width: 80%;
+    max-width: none;
+  }
+ }
+
+.form-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,26 +1,27 @@
-<h2>Sign up</h2>
+<h1>Sign up</h1>
 
-<%= form_with model: resource, url: registration_path(resource) do |f| %>
-  <div class="form-inputs">
-    <div class="form-group">
-      <%= f.label :email %>
-      <%= f.email_field :email, required: true, autofocus: true, class: "form-control" %>
+<div class="form-center">
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= f.error_notification %>
+
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" }%>
+      <%= f.input :password,
+                  required: true,
+                  hint: ("#{@minimum_password_length} characters minimum." if @minimum_password_length),
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
+                  required: true,
+                  input_html: { autocomplete: "new-password" } %>
     </div>
 
-    <div class="form-group">
-      <%= f.label :password %>
-      <%= f.password_field :password, required: true, class: "form-control" %>
+    <div class="form-actions">
+      <%= f.button :submit, "Sign up" %>
     </div>
+  <% end %>
 
-    <div class="form-group">
-      <%= f.label :password_confirmation %>
-      <%= f.password_field :password_confirmation, required: true, class: "form-control" %>
-    </div>
-  </div>
-
-  <div class="form-actions">
-    <%= f.submit "Sign up", class: "btn btn-primary" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -60,7 +60,7 @@ en:
     messages:
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      common_password: 'is a very common password. Please choose something harder to guess.'
+      common_password: 'This is a very common password. Please choose something harder to guess.'
       expired: "has expired, please request a new one"
       password_too_short: "must be at least %{count} characters"
       password_too_long: "must be at most %{count} characters"


### PR DESCRIPTION
Simple Form reintroduced for sign up form and custom sign up css introduced.

Devise custom css introduced to override Devise view page styling, in particular the sign up page for now.

Centered sign up form fields in the page and expanded their size to make it clearer to new users(particularly in case of any sign up errors).

Log in appears on the right of the form fields, working on resolving this.

Improved layout of password prompts from yml to make it clearer as to the error.