### PR TITLE
Administrate Admin/User Scenarios and Attributes Reorganised

### DIFF
--- a/app/dashboards/game_dashboard.rb
+++ b/app/dashboards/game_dashboard.rb
@@ -26,6 +26,7 @@ class GameDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
+    title
     description
     image
     main_image
@@ -35,12 +36,12 @@ class GameDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
+    title
     description
     image
     main_image
     review_scores
     slug
-    title
     created_at
     updated_at
   ].freeze
@@ -49,12 +50,12 @@ class GameDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
+    title
     description
     image
     main_image
     review_scores
     slug
-    title
   ].freeze
 
   # COLLECTION_FILTERS


### PR DESCRIPTION
Sign in is possible after approval from the Administrate admin interface.

Admin can edit and subsequently update user passwords which then feeds through to the main app also.

Search functionality is tied to being signed in as an approved by admin user.

Game titles now appear in the view index page for Admin's view of games after readjusting the game dashboard collection attributes.

Did try creating new Admin flashes view file to replicate main app flashes in admin view,
 however, the standard Administrate flashes are far more suitable in layout and appearance.