### PR TITLE
Established Genres for Games, Genres can now be associated to new and  existing Games.

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -76,7 +76,7 @@ class GamesController < ApplicationController
   private
 
   def game_params
-    params.require(:game).permit(:title, :description, :review_scores, :main_image)
+    params.require(:game).permit(:title, :description, :review_scores, :main_image, :genre_id)
   end
 
   def find_game

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,5 +7,7 @@ class Game < ApplicationRecord
   validates :review_scores, presence: true
   has_one_attached :main_image
 
+  belongs_to :genre
+
   broadcasts_refreshes
- end
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  has_many :games
+end

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -28,5 +28,10 @@
     <%= form.file_field :main_image, class: "form-control", id: "main_image", name: "game[main_image]" %>
   </div>
 
+  <div class="form-group">
+    <%= form.label :genre_id, "Select Genre:" %>
+    <%= form.collection_select :genre_id, Genre.all, :id, :name, { prompt: "Please select a genre" }, class: "form-control" %>
+  </div>
+
   <button type="submit" class="btn btn-secondary">Submit Created Game</button>
 <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,6 +2,11 @@
   <%= turbo_stream_from @game %>
   <h1><%= @game.title %></h1>
   <h2><%= @game.description %></h2>
+   <% if @game.genre %>
+    <p>Genre: <%= @game.genre.name %></p>
+  <% else %>
+    <p>Genre: TBC </p>
+  <% end %>
   <p>Game Review Score: <%= @game.review_scores %></p>
   <% if @game.main_image.attached? %>
     <%= image_tag @game.main_image, size: "500x800" %>

--- a/db/migrate/20240102193318_create_genres.rb
+++ b/db/migrate/20240102193318_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[7.1]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240102193325_create_join_table_game_genre.rb
+++ b/db/migrate/20240102193325_create_join_table_game_genre.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableGameGenre < ActiveRecord::Migration[7.1]
+  def change
+    create_join_table :games, :genres do |t|
+      # t.index [:game_id, :genre_id]
+      # t.index [:genre_id, :game_id]
+    end
+  end
+end

--- a/db/migrate/20240102212928_add_genre_id_to_games.rb
+++ b/db/migrate/20240102212928_add_genre_id_to_games.rb
@@ -1,0 +1,5 @@
+class AddGenreIdToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :genre_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_27_183721) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_02_212928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string "namespace"
+    t.text "body"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "author_type"
+    t.bigint "author_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -42,6 +56,18 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_183721) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "admin_users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
   create_table "games", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -50,7 +76,19 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_183721) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
+    t.integer "genre_id"
     t.index ["slug"], name: "index_games_on_slug", unique: true
+  end
+
+  create_table "games_genres", id: false, force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "genre_id", null: false
+  end
+
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|
@@ -80,6 +118,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_27_183721) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.boolean "approved", default: false, null: false
+    t.boolean "admin"
     t.index ["approved"], name: "index_users_on_approved"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,4 +46,8 @@ Post.create(title: "Fifth post", body: "This is the fifth post body")
                   rating: 5)
 end
 
-puts "Game Reviews generated!"
+Genre.create(name: 'Action')
+Genre.create(name: 'Adventure')
+Genre.create(name: 'Role-Playing')
+
+puts "Games, Post and Game Reviews have been generated!"

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :genre do
+    name { "MyString" }
+  end
+end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Genre, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Games can now have a specific genre assigned to them, I have setup three initial genres to demonstrate genres working. All previously created game seeds do not have a genre so they show "TBC" for their genre, however editing and updating them with a specific genre completes and updates in the show page successfully.

Game model, controller and several view files adjusted to accommodate for the inclusion of genres into games.

Several migrations required to complete the cohesion between games and genres.

The game form view when creating or editing a game has a drop down selection of the currently available genres for the specific game being created/edited.

Seed message also updated to incorporate games, genres, posts and reviews that are created within the seed file.