### PR TITLE
Genres Expanded into Games Further, Genres Controllers and Genre Views Setup

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,6 +25,7 @@ class GamesController < ApplicationController
 
   def index
     @pagy, @games = pagy(params[:query].present? ? Game.where("title LIKE ?", "%#{params[:query]}%") : Game.all, items: 10)
+    @games = Game.includes(:genre).all
 
     if params[:query].present?
       @games = Game.where("title LIKE ?", "%#{params[:query]}%")

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,0 +1,14 @@
+class GenresController < ApplicationController
+  def index
+    @genres = Genre.all
+  end
+
+  def show
+    @genre = Genre.find(params[:id])
+    @games = @genre.games
+    respond_to do |format|
+      format.html { render 'games/index' }
+      format.turbo_stream { render turbo_stream: turbo_stream.replace('games', partial: 'games_list', locals: { games: @games }) }
+    end
+  end
+end

--- a/app/helpers/genres_helper.rb
+++ b/app/helpers/genres_helper.rb
@@ -1,0 +1,2 @@
+module GenresHelper
+end

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -8,6 +8,11 @@
     <% else %>
       <%= image_tag("default.png", size: "250x400") %>
     <% end %>
+    <% if game.genre %>
+      <p>Genre: <%= game.genre.name %></p>
+    <% else %>
+      <p>Genre: To be confirmed</p>
+    <% end %>
   </div>
 
   <div id="<%= dom_id game %>">

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -7,6 +7,24 @@
 
         <h1>All Games</h1>
 
+      <%= form_tag(games_path, method: "get", remote: true) do %>
+          <div>
+            <%= radio_button_tag(:genre, "all", true) %>
+            <%= label_tag(:genre, "All") %>
+
+            <%= radio_button_tag(:genre, "action") %>
+            <%= label_tag(:genre, "Action") %>
+
+            <%= radio_button_tag(:genre, "adventure") %>
+            <%= label_tag(:genre, "Adventure") %>
+
+            <%= radio_button_tag(:genre, "role-playing") %>
+            <%= label_tag(:genre, "Role-Playing") %>
+
+            <%= submit_tag("Filter") %>
+          </div>
+      <% end %>
+
         <div id="games">
           <% @games.each do |game| %>
             <p>

--- a/app/views/genres/index.html.erb
+++ b/app/views/genres/index.html.erb
@@ -1,0 +1,35 @@
+<h1> Genres of Games </h1>
+<h2> Below is a list of Game Genres, thanks to: <%= link_to "https://plarium.com/en/blog/video-game-genres/", "https://plarium.com/en/blog/video-game-genres/", target: "_blank" %></h2>
+<div id=list>
+  <ul>
+    <li>Casual - Quick and easy-to-play games, often referred to as pick-up-and-play. Popularized in the mobile gaming sector.</li>
+    <li>MMORPG (Massive Multiplayer Online Role-Playing Game) - Games that allow players worldwide to exist in the same gaming universe. Players create characters, complete quests, and build narratives.</li>
+    <li>Tower Defense - Games where players defend a stronghold against waves of enemies, requiring resource management and tactical planning.</li>
+    <li>Shooters - Games involving guns, including first-person shooters or third-person shooters, putting players in intense combat scenarios.</li>
+    <li>War - Games set within war situations, often based on historical wars or imaginary war scenarios.</li>
+    <li>Adventure - Narrative-driven games with immersive worlds, offering various activities from solving puzzles to making choices.</li>
+    <li>Survival - Games where players gather resources and survive against hostile enemies, providing a sense of accomplishment.</li>
+    <li>Match 3 - Puzzle games requiring players to align identical tiles or objects, often involving cascading mechanics and strategic planning.</li>
+    <li>Action - Fast-paced games combining combat and exploration.</li>
+    <li>MMO (Massively Multiplayer Online) - Similar to MMORPGs but generally existing solely on mobile, focusing on cooperative or competitive gameplay.</li>
+    <li>Multiplayer - Games enabling friends or strangers to compete in shared virtual spaces, encouraging social interactions.</li>
+    <li>PvP (Player vs Player) - Titles pitting players against each other in competitive scenarios, fostering skill development and strategy formulation.</li>
+    <li>RPG (Role-Playing Game) - Games where players embody characters within fantasy worlds, making decisions that affect the story's outcome.</li>
+    <li>Strategy - Games requiring players to plan and outmaneuver opponents, inspired by classic board games like Risk.</li>
+    <li>Castle - Tower defense games involving building and defending a sturdy stronghold against enemies, featuring tactical elements.</li>
+    <li>Medieval - Games transporting players to medieval times, often including knights, chivalry, and rich narratives.</li>
+    <li>Solitaire - Recognizable computer card game, available in countless versions online with unique rules.</li>
+    <li>Puzzle - Games involving puzzles, gaining popularity in the mobile gaming market.</li>
+    <li>Robot - Games featuring robot themes, providing a glimpse into a future with prevalent artificial intelligence.</li>
+    <li>Horror - Fully immersive horror games offering thrilling and scary experiences, often with realistic graphics.</li>
+    <li>Roguelikes - Games with procedurally generated levels, permanent death consequences, and a need to start over upon dying.</li>
+    <li>Battle Royale - Genre where players compete in an ever-shrinking play area to be the last one standing.</li>
+    <li>Survival Horror - Survival horror games blending survival mechanics with frightening elements, offering tense and atmospheric experiences.</li>
+    <li>Tactical RPG - Games combining strategy and role-playing elements, featuring turn-based battles with an emphasis on tactics.</li>
+    <li>Open World Action RPG - Popular genre with a sandbox environment, detailed character progression, and storytelling.</li>
+    <li>Sandbox Simulation - Games allowing players to do anything within the game's universe, shaping their environment and creating experiences.</li>
+    <li>Stealth Action - Games with a focus on avoiding detection from enemies, requiring planning and patience.</li>
+    <li>Hack 'n' Slash RPG - Genre involving fast-paced action gameplay, button bashing in battle, and RPG mechanics for added depth.</li>
+    <li>Puzzle Platformer - Games combining platform levels with puzzles to solve, offering unique titles in the genre.</li>
+  </ul>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -21,6 +21,11 @@
       <% else %>
         <%= image_tag("default.png", size: "250x400") %>
       <% end %>
+      <% if game.genre %>
+        <p>Genre: <%= game.genre.name %></p>
+      <% else %>
+        <p>Genre: To be confirmed</p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,6 +9,7 @@
       <div class="right">
         <ul>
           <li><%= link_to "All about Nintendo", nintendo_path %></li>
+          <li><%= link_to "Game Genres", genres_path %></li>
         </ul>
       </div>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
   resource :search, controller: "search"
 
+  resources :genres
+
   root to: "pages#home"
 
   get "home", to: 'pages#home', as: :homepage

--- a/spec/helpers/genres_helper_spec.rb
+++ b/spec/helpers/genres_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GenresHelper. For example:
+#
+# describe GenresHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GenresHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/genres_spec.rb
+++ b/spec/requests/genres_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Genres", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Games now show their specifically assigned genre each and a message if they currently have no assigned genre.

Reconfigured routes to allow for genres, provided link in footer so genres can be accessed across the application.

Games index and games controller have added genre code and actions to allow the user to choose a specific genre via radio buttons for each game genre and see games for that genre. Once the genre has been selected and filter is then clicked (working on getting results to appear in the subsequent filtered genre of games page).

Genre index page trying few new items, including an external hyperlink and a list of 29 game genres courtesy of https://plarium.com/en/blog/video-game-genres/ .