### PR TITLE
Revised Game model and Rails helper test file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,8 +93,6 @@ gem "administrate-field-active_storage"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]
-  # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
   gem 'rspec-rails', '~> 6.0.3'
   gem 'factory_bot_rails'
   gem 'shoulda-matchers'
@@ -110,6 +108,10 @@ group :development, :test do
   # gem "spring"
 end
 
-gem 'dockerfile-rails', '>= 1.6', :group => :development
+group :development do
+  # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem 'web-console'
 
-gem 'kamal', '~> 1.3'
+  gem 'dockerfile-rails', '>= 1.6'
+  gem 'kamal', '~> 1.3'
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Game, type: :model do
   it "is valid with valid attributes" do
     subject.title = "Anything"
     subject.description = "Anything"
+    subject.genre = Genre.create!(attributes_for(:genre))
+    expect(subject).to be_valid
   end
 
 
@@ -23,4 +25,6 @@ RSpec.describe Game, type: :model do
     subject.description = nil
     expect(subject).to_not be_valid
   end
+
+  it { is_expected.to belong_to(:genre) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,7 +40,6 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.include FactoryBot::Syntax::Methods
-  FactoryBot.find_definitions
   FactoryBot.definition_file_paths = [File.expand_path('../factories', __FILE__)]
 
 


### PR DESCRIPTION
Improved upon game model tests due to changes since the previous RSpec tests created. Including accounting for Genre now featuring in the Game model with an additional test for Genre and also that a valid attribute Genre test now exists.

Removed FactoryBot find definitions line from rails_helper test configuration file as it was affecting tests that would be passing without the line.

Readjusted Gemfile to place web-console gem in development group of gems as it was affecting running RSpec tests.