### PR TITLE
Added to Nintendo Page and Created partial for Page Content

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -74,6 +74,10 @@ class GamesController < ApplicationController
     end
   end
 
+  def nintendo
+    @games = Game.where("title LIKE ?", "%Mario%") 
+  end
+
   private
 
   def game_params

--- a/app/views/games/nintendo.html.erb
+++ b/app/views/games/nintendo.html.erb
@@ -1,23 +1,13 @@
 <h1>Nintendo Games</h1>
-
 <h2>Nintendo's wide variety of games!</h2>
 
-<h3>Work in progress...</h3>
+<%= render "games/nintendo/nintendo_content" %>
 
-  <%= search_input('text', 'Type to Search...') %>
-
-  <ul class="card-container">
-    <li class="card">1</li>
-    <li class="card">2</li>
-    <li class="card">3</li>
-    <li class="card">4</li>
-    <li class="card">5</li>
-    <li class="card">6</li>
-  </ul>
-
-
-<div class="loadingio-spinner-spinner-2pcnwbnmf5e"><div class="ldio-4vh0oxhxr1f">
-<div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
-</div></div>
-
- <%= link_to "Homepage", homepage_path %>
+<% if @games.present? %>
+  <% @games.each do |game| %>
+    <li class="card">
+      <%= game.title %> </li>
+  <% end %>
+<% else %>
+  <p>If this message is showing, no games have been found.</p>
+<% end %>

--- a/app/views/games/nintendo/_nintendo_content.html.erb
+++ b/app/views/games/nintendo/_nintendo_content.html.erb
@@ -1,0 +1,9 @@
+<p>The best of Mario from Nintendo!</p>
+
+<ul class="card-container">
+  <% @games.each do |game| %>
+    <li class="card">
+      <%= render "game", game: game %>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
Nintendo page now has games controller action pointing Mario games to being displayed in the page, pulling Mario games in from the Faker seed file.

Removed Homepage link as this now exists within the header across the application's view pages.

Updated view text to no longer refer to the Nintendo page as work in progress,

New partial created to move content related code from the Nintendo view page into as it was congested and non-coherent previously. Will aim to move further code from the view page into it going forward.

Appearance is not 100% and will be improved upon in the next code submitted for this branch.