### PR TITLE
Nintendo View Page Refinements and Separate App Tweaks

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,17 +1,16 @@
 .card {
   --background: linear-gradient(to left, #f7ba2b 0%, #ea5358 100%);
-  width: 190px;
-  height: 254px;
-  padding: 5px;
+  width: 200px; /* Adjusted width for a more balanced layout */
+  height: 300px; /* Adjusted height for better visibility */
+  padding: 15px; /* Increased padding for better spacing */
   border-radius: 1rem;
-  overflow: visible;
-  background: #f7ba2b;
+  overflow: hidden; /* Changed to hidden for a cleaner look */
   background: var(--background);
   position: relative;
-  z-index: 1;
-  flex: 0 0 33.333%;
-  max-width: 33.333%;
- }
+  flex: 0 0 30%;
+  max-width: 30%;
+  transition: transform 0.3s;
+}
 
  .card-container {
   display: flex;
@@ -21,21 +20,10 @@
   justify-content: center;
 }
 
- .card::after {
-  position: absolute;
-  content: "";
-  top: 30px;
-  left: 0;
-  right: 0;
-  z-index: -1;
-  height: 100%;
-  width: 100%;
-  transform: scale(0.8);
-  filter: blur(25px);
-  background: #f7ba2b;
-  background: var(--background);
-  transition: opacity .5s;
- }
+.card::after {
+  filter: blur(15px);
+  transition: opacity 0.5s, transform 0.5s;
+}
 
  .card-info {
   --color: #181818;

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "stimulus"
 import ToggleController from "./controllers/toggle_controller"
 
 export default class extends Controller {

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(game) do %>
   <div class="game">
-    <h2><%= game.title %></h2>
+    <h2><%= link_to game.title, game_path(game), data: { turbo_frame: "_top" } %></h2>
     <p><%= game.description %></p>
     <p>Review Score: <%= game.review_scores %></p>
     <% if game.main_image.attached? %>
@@ -13,11 +13,5 @@
     <% else %>
       <p>Genre: To be confirmed</p>
     <% end %>
-  </div>
-
-  <div id="<%= dom_id game %>">
-    <p class="text-lg leading-loose">
-      <%= link_to game.title, game_path(game), class: "text-orange-600 underline hover:text-orange-700" %>
-    </p>
   </div>
 <% end %>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -7,7 +7,7 @@
 
         <h1>All Games</h1>
 
-      <%= form_tag(games_path, method: "get", remote: true) do %>
+      <%= form_tag(games_path, data: { turbo_frame: "_top" }, method: "get", remote: true) do %>
           <div>
             <%= radio_button_tag(:genre, "all", true) %>
             <%= label_tag(:genre, "All") %>

--- a/app/views/games/nintendo.html.erb
+++ b/app/views/games/nintendo.html.erb
@@ -2,12 +2,3 @@
 <h2>Nintendo's wide variety of games!</h2>
 
 <%= render "games/nintendo/nintendo_content" %>
-
-<% if @games.present? %>
-  <% @games.each do |game| %>
-    <li class="card">
-      <%= game.title %> </li>
-  <% end %>
-<% else %>
-  <p>If this message is showing, no games have been found.</p>
-<% end %>

--- a/app/views/games/nintendo/_nintendo_content.html.erb
+++ b/app/views/games/nintendo/_nintendo_content.html.erb
@@ -2,8 +2,6 @@
 
 <ul class="card-container">
   <% @games.each do |game| %>
-    <li class="card">
-      <%= render "game", game: game %>
-    </li>
+    <%= render "game", game: game %>
   <% end %>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
     <title>GamesonRails</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
@@ -11,13 +12,12 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css" integrity="sha384-pzjw8P+6fs8KXjp0WjBYzV1PW7I3IjQ8EAtwDAL+tn5CqG62OMZ8u7zkiYt9oPIJ" crossorigin="anonymous">
-    <%= turbo_refreshes_with method: :morph, scroll: :preserve  %>
     <%= content_for :head %>
   </head>
 
   <body>
     <%= render "shared/navbar" %>
-    
+
     <turbo-frame id="flash">
       <%= render 'shared/flash' %>
       <%= render "shared/flashes" %>


### PR DESCRIPTION
Removed cards from the Nintendo page due to their effect on the page layout in particular with their overlapping of the footer, envisage to add cards to this page again soon. Also now only shows the links in the game titles, rather than in a separate place below the game record and surrounding information.

Cards css has been refined to be much more like the Featured Games on the homepage, will be revisited in the future when cards themselves are added again to this page.

Turbo updated in several places to fix the content missing error, with games the links should now work rather than providing a "Content missing" error. Also moved Turbo code placement in application view page to appear before other head code.

Updated calling path for toggle_controller to be just Stimulus.