### PR TITLE
Adjustment to Genre in Game Model to fix failing deployment.

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,7 +7,7 @@ class Game < ApplicationRecord
   validates :review_scores, presence: true
   has_one_attached :main_image
 
-  belongs_to :genre
+  belongs_to :genre, optional: true
 
   broadcasts_refreshes
 end


### PR DESCRIPTION
During a Rails deployment of the application, the following line was appearing: ActiveRecord::RecordInvalid: Validation failed: Genre must exist.

Following research into other users experiencing this issue, I have discovered that adding the code "optional: true" into the model where the specific class code (in this case Genre in Game) is called in belongs_to as a potential solution to the issue preventing the deployment.