### PR TITLE
Navbar converted into Two Separate Stimulus dropdowns

### DIFF
--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -55,4 +55,12 @@ a {
     margin-bottom: 10px;
     margin-right: 0;
   }
+
+  .dropdownContent {
+    background-color: red;
+    position: fixed;
+    padding: 4px;
+    z-index: 2;
+    border-radius: 6px;
+  }
 }

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,7 +1,49 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  submit() {
-    this.element.requestSubmit();
+  static targets = ["dropdownContent", "openButton", "closeButton", "active"]
+  static values = { open: Boolean }
+  static classes = ["opened"]
+
+  connect() {
+    if (this.openValue) {
+      this.openDropdown()
+    } else {
+      this.closeDropdown()
+    }
+    // this.dropdownContentTarget.hidden = true
+    // this.closeButtonTarget.hidden = true
+    // console.log("hello")
   }
+
+  toggleDropdown() {
+    if (this.dropdownContentTarget.hidden == true) {
+      this.openDropdown()
+    } else {
+      this.closeDropdown()
+    }
+  }
+
+  openDropdown() {
+    this.dropdownContentTarget.hidden = false
+    try {
+    this.openButtonTarget.hidden = true
+    this.closeButtonTarget.hidden = false } catch {}
+    try {
+      // this.activeTarget.classList.add("bg-zinc-400")
+      this.activeTarget.classList.add(this.openedClass)
+    } catch {}
+  }
+
+  closeDropdown() {
+    this.dropdownContentTarget.hidden = true
+    try {
+    this.openButtonTarget.hidden = false
+    this.closeButtonTarget.hidden = true } catch {}
+    try {
+      // this.activeTarget.classList.remove("bg-zinc-400")
+      this.activeTarget.classList.remove(this.openedClass)
+    } catch {}
+  }
+
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,11 +1,19 @@
 <header>
     <div class="left-nav">
-      <ul>
-        <li><%= link_to "Homepage", homepage_path %></li>
-        <li><%= link_to "Games List", index_path %></li>
-        <li><%= link_to "Posts", posts_path %></li>
-        <li><%= link_to "Reviews", reviews_path %></li>
-      </ul>
+      <div data-controller="dropdown" data-dropdown-open-value="false" data-dropdown-opened-class="bg-slate-300">
+        <button data-dropdown-target="activated" data-action="click->dropdown#toggleDropdown">
+          Key Pages
+        </button>
+
+        <div data-dropdown-target="dropdownContent" class="bg-red-500 fixed p-4 rounded-md">
+          <ul>
+            <li><%= link_to "Homepage", homepage_path %></li>
+            <li><%= link_to "Games List", index_path %></li>
+            <li><%= link_to "Posts", posts_path %></li>
+            <li><%= link_to "Reviews", reviews_path %></li>
+          </ul>
+        </div>
+      </div>
     </div>
 
     <div class="middle-nav">
@@ -15,10 +23,18 @@
     </div>
 
     <div class="right-nav">
-      <ul>
-        <li><%= link_to "Add a Game", new_game_path %>
-        <li><%= link_to "Delete a Game", games_path(@game), method: :delete %></li>
-        <li><%= link_to "Edit a Game", games_path(@game), method: :edit %></li>
-      </ul>
+      <div data-controller="dropdown" data-dropdown-open-value="false" data-dropdown-opened-class="bg-slate-300">
+        <button data-dropdown-target="activated" data-action="mouseenter->dropdown#toggleDropdown mouseleave->dropdown#toggleDropdown">
+          Game Actions
+        </button>
+
+        <div data-dropdown-target="dropdownContent" class="bg-red-500 fixed p-4 rounded-md">
+          <ul>
+            <li><%= link_to "Add a Game", new_game_path %>
+            <li><%= link_to "Delete a Game", games_path(@game), method: :delete %></li>
+            <li><%= link_to "Edit a Game", games_path(@game), method: :edit %></li>
+          </ul>
+        </div>
+      </div>
     </div>
 </header>


### PR DESCRIPTION
Added new Stimulus dropdown controller code, adjusted placement of existing index JS controller Stimulus dropdown code and added to this also.

Left and right side of the Navbar have been converted into two types of Navbar Dropdowns. For the left side of the navbar, this is now open on a click, and closes on a subsequent click. The right navbar has been transformed into an open on hover, and then when hovered over again closes back into the button.

As the buttons are aligning to the far left and right sides of the page, this will be looked into for the next commit for this branch.

Added css for the dropdown content however I feel this is being overrided by previously introduced css elsewhere.