### PR TITLE
Request Specs Updated, Rails Controller Testing Gem added for Extending Request Specs Possibilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem "administrate"
 # For Administrate running with ActiveStorage
 gem "administrate-field-active_storage"
 
+# For RSpec request specs
+gem 'rails-controller-testing'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,10 @@ GEM
       activesupport (= 7.1.1)
       bundler (>= 1.15.0)
       railties (= 7.1.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -412,6 +416,7 @@ DEPENDENCIES
   pg (~> 1.5.4)
   puma (~> 6.4.0)
   rails (~> 7.1)
+  rails-controller-testing
   rspec-rails (~> 6.0.3)
   sassc-rails
   selenium-webdriver

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'rails-controller-testing'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,17 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe "Games", type: :request do
-  describe "GET /games" do
-    it "renders the intended response" do
-      get "/games"
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
-  describe "GET /nintendo" do
-    it "renders the intended response" do
-      get "/nintendo"
-      expect(response).to have_http_status(:ok)
-    end
+RSpec.describe "Games Show page", type: :request do
+  it "renders the Games Show page" do
+    get "/games/show"
+    expect(response).to render_template(:show)
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Sign In Page", type: :request do
+  describe "GET /users/sign_in" do
+    it "Renders the user sign in page" do
+      get "/users/sign_in"
+      expect(response).to render_template(:sign_in)
+    end
+  end
+end


### PR DESCRIPTION
Added rails-controller-testing gem to assist with the route guidance in request test specs to ensure they direct in the right direction.

Testing locally the specs will fail (however they currently point in the right direction),this is due to two factors, first with the games spec, user authentication is required in the current route the spec path takes. 

The second factor is that with the user request spec various partials are opening from Devise and shared partials, in particular "devise/sessions/new" is being rendered which is the intended outcome and can later be restyled in the spec to achieve this (the same applies to the newly added game spec also).