### PR TITLE
Edit and Show Review Displaying Trix and Trix CSS Updated

### DIFF
--- a/app/assets/stylesheets/_trix.scss
+++ b/app/assets/stylesheets/_trix.scss
@@ -1,0 +1,15 @@
+// Change the background color of the buttons
+trix-toolbar .trix-button-group button {
+  background-color: rgb(255, 255, 255);
+}
+
+// Remove the bold button icon
+trix-toolbar .trix-button-group button.trix-button--icon-bold::before {
+  background-image: none;
+}
+
+// Change the background color of the Trix editor
+.trix-content {
+  background-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -29,19 +29,3 @@
   padding: 0 !important;
   max-width: 100% !important;
 }
-
-/* Change the background color of the buttons */
-.trix-toolbar .trix-button-group button {
-  background-color: white;
-}
-
-/* Change the color of the button icons */
-.trix-toolbar .trix-button-group button svg {
-  fill: rgb(255, 255, 255);
-}
-
-/* Change the color of the selected text */
-trix-editor [contenteditable=true]:focus::selection {
-  background-color: rgb(255, 255, 255);
-  color: white;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,7 +36,8 @@
 @import 'devise_custom';
 
 // For Action Text/Trix
-@import 'actiontext.css'
+@import 'actiontext.css';
+@import "trix"
 
 
 // external libraries below

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -66,6 +66,6 @@ class ReviewsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def review_params
-      params.require(:review).permit(:title, :body, :rating)
+      params.require(:review).permit(:title, :body, :rating, :content)
     end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,5 +3,5 @@ class Review < ApplicationRecord
   validates :body, presence: true
   validates :rating, presence: true
   has_one_attached :main_image
-  has_rich_text :review
+  has_rich_text :content
 end

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,5 +1,3 @@
-<trix-editor class="trix-content">
-  <div class="trix-content">
-    <%= yield -%>
-  </div>
-</trix-editor>
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css" integrity="sha384-pzjw8P+6fs8KXjp0WjBYzV1PW7I3IjQ8EAtwDAL+tn5CqG62OMZ8u7zkiYt9oPIJ" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">
+    <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
     <%= content_for :head %>
   </head>
 

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,11 +1,13 @@
 <%= form_with model: @review do |f| %>
-  <%= f.label :title %>
-  <%= f.text_field :title %>
-   <%= f.label :body %>
-  <%= f.text_area :body %>
-  <%= f.label :review %>
-  <%= f.rich_text_area :review %>
-  <%= f.label :rating %>
-  <%= f.number_field :rating %>
-  <%= f.submit "Create" %>
+  <div class="field">
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+    <%= f.label :body %>
+    <%= f.text_area :body %>
+    <%= f.label :content %>
+    <%= f.rich_text_area :content %>
+    <%= f.label :rating %>
+    <%= f.number_field :rating %>
+    <%= f.submit "Create" %>
+  </div>
 <% end %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -10,8 +10,8 @@
   </p>
 
   <p>
-    <h3>The Review</h3>
-    <%= review.review %>
+    <Strong>Review:</strong>
+    <%= review.content %>
   </p>
 
   <p>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -5,8 +5,6 @@
 
 <%= render @review %>
 
-<%= @review.review %>
-
 <div>
   <%= link_to "Edit this review", edit_review_path(@review) %> |
   <%= link_to "Back to reviews", reviews_path %>


### PR DESCRIPTION
Replaced Trix rich text name of "review" with "content" to separate it from the preexisting use of review in the review MVC's and as part of the game MVC's.

Added to the private review_params method ":content" to ensure it now displays in the show and edit Review view pages.

Cut out CSS added to Trix previously and created a new Trix CSS file and called in the application.scss file and also to the application.html.erb file to ensure the new CSS displays, CSS implemented in the new CSS partial is working in the form as lots of elements of Trix now appear in white rather than black which affected visibility of Trix due to the black background in the application. It also on view pages of the reviews appeared with a white background, will fix this in the next commit for this branch.