### PR TITLE
Comments setup inside Game records

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,22 @@
+class CommentsController < ApplicationController
+  def create
+    @game = Game.friendly.find(params[:game_id])
+    @comment = @game.comments.new(comment_params)
+
+    respond_to do |format|
+      if @comment.save
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: Comment.new }) }
+        format.html { render partial: 'comments/form', locals: { comment: Comment.new }}
+      else
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: @comment }) }
+        format.html { render partial: 'comments/form', locals: { comment: @comment }}
+      end
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body)
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  after_create_commit { broadcast_append_later_to @game, target: "comments" }
+
+  belongs_to :game
+  validates :body, presence: true, length: { minimum: 4 }
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -8,6 +8,7 @@ class Game < ApplicationRecord
   has_one_attached :main_image
 
   belongs_to :genre, optional: true
+  has_many :comments, dependent: :destroy
 
   broadcasts_refreshes
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,3 @@
+<div id="<%= dom_id(comment) %>">
+  <%= comment.body %>
+</div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag "comment_form" do %>
+  <%= form_with model: comment, url: game_comments_path(@game) do |form| %>
+    <% if comment.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(comment.errors.count, "error") %> has prohibited this comment from being saved:</h2>
+
+        <ul>
+          <% comment.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <%= form.text_field :body %>
+    <%= form.submit %>
+  <% end %>
+<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -13,6 +13,12 @@
   <% else %>
      <%= image_tag("default.png", size: "500x800") %>
   <% end %>
+
+  <%= render partial: "comments/form", locals: { comment: Comment.new } %>
+  <%= turbo_stream_from @game, :comments %>
+  <div id="<%= "#{dom_id(@game)}_comments" %>">
+    <%= render @game.comments.order(created_at: :desc) %>
+  </div>
 </div>
 
 <li class="list-group-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     collection do
       post :preview
     end
+
+    resources :comments, only: %i[create]
   end
 
   resource :search, controller: "search"

--- a/db/migrate/20240114145939_create_comments.rb
+++ b/db/migrate/20240114145939_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.references :game, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_12_191755) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_14_145939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_12_191755) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "game_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_comments_on_game_id"
+  end
+
   create_table "games", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -136,4 +144,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_12_191755) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "games"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :comment do
+    body { "MyText" }
+    game { nil }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Comments have been setup with their own MVC architecture, and display inside game records.

Comments created are able to created without being a user (for now) and will only display on the Game show pages to minimise long lists of popular games with many comments across the application.

Emphasis is on the comments code be as separate as possible from the game code to avoid too many overlaps and confusions, and to only have the two appear in conjunction wherever necessary.

Will implement CSS for the Comments in the future, for both the created comments appearance and the form to create them.

Turbo fuctionality is not fully realised as it is not displaying newly created comments live and rather currently requires a page refresh to display the newly added comments, next commit in this branch should fix this.