### PR TITLE
Updated Comments to render in Real Time, Turbo Rails Gem Update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'puma', '~> 6.4.2'
 gem 'importmap-rails'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem 'turbo-rails', '~> 2.0.0.pre.beta'
+gem 'turbo-rails', '~> 2.0.0.pre.beta.2'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem 'stimulus-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ GEM
     time (0.2.2)
       date
     timeout (0.4.0)
-    turbo-rails (2.0.0.pre.beta.1)
+    turbo-rails (2.0.0.pre.beta.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -424,7 +424,7 @@ DEPENDENCIES
   simple_form
   sprockets-rails
   stimulus-rails
-  turbo-rails (~> 2.0.0.pre.beta)
+  turbo-rails (~> 2.0.0.pre.beta.2)
   tzinfo-data
   web-console
   webdrivers

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
-  after_create_commit { broadcast_append_later_to @game, target: "comments" }
+  include ActionView::RecordIdentifier
+  after_create_commit { broadcast_prepend_to [game, :comments], target: "#{dom_id(game)}_comments" }
 
   belongs_to :game
   validates :body, presence: true, length: { minimum: 4 }

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_stream_from @game %>
 <div id="<%= dom_id(comment) %>">
   <%= comment.body %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: comment, url: game_comments_path(@game) do |form| %>
     <% if comment.errors.any? %>
       <div id="error_explanation">
-        <h2><%= pluralize(comment.errors.count, "error") %> has prohibited this comment from being saved:</h2>
+        <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
 
         <ul>
           <% comment.errors.each do |error| %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,5 +1,4 @@
 <div class="game">
-  <%= turbo_stream_from @game %>
   <h1><%= @game.title %></h1>
   <h2><%= @game.description %></h2>
    <% if @game.genre %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+    <%= turbo_stream_from @game %>
     <title>GamesonRails</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
Comments now render without a page reload being necessary following turbo_stream changes in several files, including moving turbo_stream from the game show page to the layouts/application page. Added into the comment partial also to help with the real time rendering of newly created comments.

Also updated the Turbo Rails gem to 2.0.0.pre.beta.2 from beta.1.