### PR TITLE
Updated to make sure Real Time Comments Creation and Deletions Occur

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,15 +2,28 @@ class CommentsController < ApplicationController
   def create
     @game = Game.friendly.find(params[:game_id])
     @comment = @game.comments.new(comment_params)
-
     respond_to do |format|
       if @comment.save
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: Comment.new }) }
-        format.html { render partial: 'comments/form', locals: { comment: Comment.new }}
+        format.turbo_stream
+        format.html { redirect_to @game }
       else
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('comment_form', partial: 'comments/form', locals: { comment: @comment }) }
-        format.html { render partial: 'comments/form', locals: { comment: @comment }}
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@comment, partial: "comments/form", locals: { comment: @comment }) }
+        format.html { render "games/show" }
       end
+    end
+  end
+
+  def show
+    @comment = Comment.find(params[:id])
+    redirect_to game_path(@comment.game)
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to game_path(@comment.game) }
     end
   end
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,5 @@
 <%= turbo_stream_from @game %>
 <div id="<%= dom_id(comment) %>">
   <%= comment.body %>
+  <%= link_to "Delete", game_comment_path(comment.game, comment), data: { "turbo-method": :delete } %>
 </div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append "#{dom_id(@game)}_comments" do %>
+  <%= render @comment %>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @comment %>

--- a/app/views/comments/replace.turbo_stream.erb
+++ b/app/views/comments/replace.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "new_comment" do %>
+  <%= render partial: "comments/form", locals: { comment: Comment.new } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       post :preview
     end
 
-    resources :comments, only: %i[create]
+    resources :comments
   end
 
   resource :search, controller: "search"


### PR DESCRIPTION
Discovered that despite the previous commit having working code to create comments in real time and without requiring a page reload, it was no longer working, revised the code and included several new partials to ensure the real time updates are taking place.

Also updated the routes to add in a new delete action for comments, which also deletes the comments individually per click of the "Delete" link, courtesy of a turbo_method as opposed to a standard Rails delete action. Comments controller also updated accordingly with show and delete action code to ensure the deletions of comments occur.