### PR TITLE
Replies to Comments Setup, Path Towards Nested Comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,5 +3,8 @@ class Comment < ApplicationRecord
   after_create_commit { broadcast_prepend_to [game, :comments], target: "#{dom_id(game)}_comments" }
 
   belongs_to :game
+  has_many :replies, class_name: 'Comment', foreign_key: :parent_id, dependent: :destroy
+  belongs_to :parent, class_name: 'Comment', optional: true
+  
   validates :body, presence: true, length: { minimum: 4 }
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,18 @@
 <%= turbo_stream_from @game %>
 
 <div id="<%= dom_id(comment) %>" class="comment">
-  <p class="comment-body"><%= comment.body %></p>
+  <div class="comment">
+    <%= comment.body %>
+    <% comment.replies.each do |reply| %>
+      <div class="reply">
+        <blockquote>
+          <%= reply.comment.body %>
+        </blockquote>
+        <%= reply.body %>
+        <%= render partial: "comments/comment", locals: { comment: reply } %>
+      </div>
+    <% end %>
+  </div>
   <%= button_to "Delete", game_comment_path(comment.game, comment), remote: true, method: :delete,
    class: "comment-delete-link" %>
 </div>

--- a/app/views/comments/_replies.html.erb
+++ b/app/views/comments/_replies.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_stream_from @game %>
+
+<div id="<%= dom_id(comment) %>" class="comment">
+  <p class="comment-body"><%= comment.body %></p>
+  <%= button_to "Delete", game_comment_path(comment.game, comment), remote: true, method: :delete,
+   class: "comment-delete-link" %>
+</div>
+
+<% comment.replies.each do |reply| %>
+  <div class="comment-reply">
+    <p class="comment-reply-body"><%= reply.body %></p>
+    <%= button_to "Delete", game_comment_path(reply.game, reply), remote: true, method: :delete,
+     class: "comment-delete-link" %>
+  </div>
+<% end %>
+
+<%= form_with(model: [comment.game, comment.replies.build], remote: true) do |form| %>
+  <div class="field">
+    <%= form.label :body %>
+    <%= form.text_area :body, rows: 2 %>
+  </div>
+  <div class="actions">
+    <%= form.submit "Reply", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -14,6 +14,7 @@
   <% end %>
 
   <%= render partial: "comments/form", locals: { comment: Comment.new } %>
+  <%= render partial: "comments/replies", collection: @game.comments, as: :comment %>
   <%= turbo_stream_from @game, :comments %>
   <div id="<%= "#{dom_id(@game)}_comments" %>">
     <%= render @game.comments.order(created_at: :desc) %>

--- a/db/migrate/20240117203442_add_parent_id_to_comments.rb
+++ b/db/migrate/20240117203442_add_parent_id_to_comments.rb
@@ -1,0 +1,6 @@
+class AddParentIdToComments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :comments, :parent_id, :integer
+    add_index :comments, :parent_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_14_145939) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_17_203442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,7 +83,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_14_145939) do
     t.bigint "game_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "parent_id"
     t.index ["game_id"], name: "index_comments_on_game_id"
+    t.index ["parent_id"], name: "index_comments_on_parent_id"
   end
 
   create_table "games", force: :cascade do |t|


### PR DESCRIPTION
Following adjustments to the comment model and database schema via a new migration replies to comments are now possible.

Despite Replies to comments being setup, as a text box will appear so that a comment can be replied to, however as of this commit it displays upon page reload and at the bottom of the game show page. Replies partial created and expanded upon the comments partial with reply code (likely will reduce this later once replies and nested comments are appearing as intended).

Eventual goal is to achieve nested comments, however for now have achieved replies to comments, next commit will hope to have a deeper association between the initial comment and the reply to it.

Have also added block quotes code to eventually also have replies reference the original comment they are replying to due to a quotation of the original comment in the reply.