### PR TITLE
Featured Reviews Setup and Additional Code Revisions

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@ class PagesController < ApplicationController
 
   def home
     @featured_games = Game.order("RANDOM()").limit(10)
+    @featured_reviews = Review.order("RANDOM()").limit(2)
   end
 
   def about

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -59,13 +59,12 @@ class ReviewsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_review
-      @review = Review.find(params[:id])
-    end
+  def set_review
+    @review = Review.find(params[:id])
+  end
 
-    # Only allow a list of trusted parameters through.
-    def review_params
-      params.require(:review).permit(:title, :body, :rating, :content)
-    end
+
+  def review_params
+    params.require(:review).permit(:title, :body, :rating, :content)
+  end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -30,6 +30,13 @@
   <% end %>
 </div>
 
+<div class="featured-reviews">
+  <% @featured_reviews.each do |review| %>
+    <h2><%= review.title %></h2>
+    <p><%= review.content %></p>
+  <% end %>
+</div>
+
 <p style="color: green"><%= notice %></p>
 
 <%= turbo_frame_tag "form" do %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -3,6 +3,7 @@
 
 <p style="color: green"><%= notice %></p>
 
+
 <%= render @review %>
 
 <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,6 @@ Rails.application.routes.draw do
 
   get "nintendo", to: "games#nintendo", as: :nintendo
 
-
   get :comments, to: 'posts#comments'
 
   get "posts", to: "posts#index"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,13 +41,16 @@ Post.create(title: "Fourth post", body: "This is the fourth post body")
 Post.create(title: "Fifth post", body: "This is the fifth post body")
 
 10.times do
-  Review.create!(title: "Great game",
-                  body: "I really enjoyed playing this game",
-                  rating: 5)
+  Review.create!(
+    title: Faker::Lorem.sentence(word_count: 3),
+    body: Faker::Lorem.paragraph(sentence_count: 1),
+    content: Faker::Lorem.paragraph(sentence_count: 3),
+    rating: rand(1..5)
+  )
 end
 
 Genre.create(name: 'Action')
 Genre.create(name: 'Adventure')
 Genre.create(name: 'Role-Playing')
 
-puts "Games, Post and Game Reviews have been generated!"
+puts "Games, Post, Genres and Game Reviews have been generated!"


### PR DESCRIPTION
Added new instance for featured_reviews inside the pages controller in order to render two random (for now) reviews in the application's homepage. Instructed the homepage to only generate the review's title and rich text content fields for now, to not overpopulate the homepage with review fields.

Updated review seeds block to populate seeds with the recently introduced rich text content so it features on seeds in the entire review seed population reviews/index page and the to instances of reviews in the homepage.

Also tidied up code in several other files.