### PR TITLE
Converted Navbar to only use Dropdown, Simplified Dropdown Stimulus Controller

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -3,7 +3,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["dropdownContent", "openButton", "closeButton", "active"]
   static values = { open: Boolean }
-  static classes = ["opened"]
 
   connect() {
     if (this.openValue) {
@@ -11,39 +10,26 @@ export default class extends Controller {
     } else {
       this.closeDropdown()
     }
-    // this.dropdownContentTarget.hidden = true
-    // this.closeButtonTarget.hidden = true
-    // console.log("hello")
   }
 
   toggleDropdown() {
-    if (this.dropdownContentTarget.hidden == true) {
-      this.openDropdown()
-    } else {
-      this.closeDropdown()
-    }
+    this.dropdownContentTarget.classList.toggle("hidden")
+    this.openButtonTarget.classList.toggle("hidden")
+    this.closeButtonTarget.classList.toggle("hidden")
+    this.activeTarget.classList.toggle("bg-zinc-400")
   }
 
   openDropdown() {
-    this.dropdownContentTarget.hidden = false
-    try {
-    this.openButtonTarget.hidden = true
-    this.closeButtonTarget.hidden = false } catch {}
-    try {
-      // this.activeTarget.classList.add("bg-zinc-400")
-      this.activeTarget.classList.add(this.openedClass)
-    } catch {}
+    this.dropdownContentTarget.classList.remove("hidden")
+    this.openButtonTarget.classList.add("hidden")
+    this.closeButtonTarget.classList.remove("hidden")
+    this.activeTarget.classList.add("bg-zinc-400")
   }
 
   closeDropdown() {
-    this.dropdownContentTarget.hidden = true
-    try {
-    this.openButtonTarget.hidden = false
-    this.closeButtonTarget.hidden = true } catch {}
-    try {
-      // this.activeTarget.classList.remove("bg-zinc-400")
-      this.activeTarget.classList.remove(this.openedClass)
-    } catch {}
+    this.dropdownContentTarget.classList.add("hidden")
+    this.openButtonTarget.classList.remove("hidden")
+    this.closeButtonTarget.classList.add("hidden")
+    this.activeTarget.classList.remove("bg-zinc-400")
   }
-
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,7 +6,7 @@
         </button>
 
         <div data-dropdown-target="dropdownContent" class="bg-red-500 fixed p-4 rounded-md">
-          <ul>
+          <ul class="navbar-nav mr-auto">
             <li><%= link_to "Homepage", homepage_path %></li>
             <li><%= link_to "Games List", index_path %></li>
             <li><%= link_to "Posts", posts_path %></li>
@@ -24,7 +24,7 @@
 
     <div class="right-nav">
       <div data-controller="dropdown" data-dropdown-open-value="false" data-dropdown-opened-class="bg-slate-300">
-        <button data-dropdown-target="activated" data-action="mouseenter->dropdown#toggleDropdown mouseleave->dropdown#toggleDropdown">
+        <button data-dropdown-target="activated" data-action="click->dropdown#toggleDropdown">
           Game Actions
         </button>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -19,3 +19,5 @@ pin "stimulus-scroll-reveal", to: "https://ga.jspm.io/npm:stimulus-scroll-reveal
 
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.js"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"


### PR DESCRIPTION


Navbar hover functionality was not working as intended with the right nav in the navbar, therefore replaced the hover action with  the dropdown action from the left nav.

Stimulus dropdown controller code as existing code was too long for what it was now doing, did not require excessive code explaining actions in depth. Reduced the controller to be only 35 lines.

Also reran the rails stimulus:install to test the dropdown action was working as intended after the Stimulus dropdown controller and navbar view changes, which it is. This action appears to have also pinned further Stimulus functions being used in the application.