### PR TITLE
Nintendo Page Filtered by Game Franchise Added, Sorts based on Checkbox Ticked

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@
 @import "navbar";
 @import "footer";
 @import "pagination";
+@import "toggle";
 
 @import "components/btn";
 @import "components/btn";

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -34,6 +34,10 @@ class GamesController < ApplicationController
       @game = Game.new
     end
 
+    if params[:game_title].present?
+      @games = Game.where(game_title: 'Mario').where("title LIKE ?", "%#{params[:@game][:title]}%")
+    end
+
     respond_to do |format|
       format.turbo_stream
       format.html do

--- a/app/views/games/nintendo/_nintendo_content.html.erb
+++ b/app/views/games/nintendo/_nintendo_content.html.erb
@@ -1,9 +1,18 @@
-<p>The best of Mario from Nintendo!</p>
-
 <div class="flex-container">
+  <%= form_tag nintendo_games_path, method: :get do %>
+    <%= check_box_tag(:Game_Franchise, 'Mario', params[:Game_Franchise] == 'Mario', onchange: "this.form.submit();") %>
+    <%= label_tag(:Game_Franchise, "Mario") %>
+  <% end %>
+
   <ul class="card-container">
-    <% @games.each do |game| %>
-      <%= render "game", game: game %>
+    <% if params[:Game_Franchise].present? %>
+      <% @games.each do |game| %>
+        <% if game.franchise == 'Mario' %>
+          <%= render "game", game: game %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p>No Games currently displayed</p>
     <% end %>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   get "edit", to: "games#edit", as: :edit
 
   get "nintendo", to: "games#nintendo", as: :nintendo
+  get 'nintendo_games', to: 'games#nintendo', as: :nintendo_games
 
   get :comments, to: 'posts#comments'
 

--- a/db/migrate/20240121161503_add_franchise_to_games.rb
+++ b/db/migrate/20240121161503_add_franchise_to_games.rb
@@ -1,0 +1,5 @@
+class AddFranchiseToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :franchise, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_18_204944) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_21_161503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_18_204944) do
     t.datetime "updated_at", null: false
     t.string "slug"
     t.integer "genre_id"
+    t.string "franchise"
     t.index ["slug"], name: "index_games_on_slug", unique: true
   end
 


### PR DESCRIPTION
I am looking to introduce a variety of new functions for the application as part of this new branch, this new feature is sorting through existing records and displaying the records found based on the game franchise they belong to (created migration file and migrated it to join it on to the schema).

The checkbox once ticked (as of now) reloads the page and the intention is it will generate only the games from the game franchise that has been ticked, later I would like to avoid the additional wait time of a page reload via using Turbo for real time record filtering.

Adjusted the routes to accommodate for the new nintendo_games_path in the _nintendo_content partial, will likely require revision in the future depending upon action chosen as to how game franchises are filtered.

CSS reference to toggle added in application.scss as intend to include a toggle perhaps with the checkboxes or replacing them later on.